### PR TITLE
Further fix a couple of links

### DIFF
--- a/src/const-eval.md
+++ b/src/const-eval.md
@@ -35,11 +35,11 @@ Other constants get represented as [`ConstValue::Scalar`]
 or [`ConstValue::Slice`] if possible. This means that the `const_eval_*`
 functions cannot be used to create miri-pointers to the evaluated constant.
 If you need the value of a constant inside Miri, you need to directly work with
-[`eval_const_to_op`].
+[`const_to_op`].
 
 [`GlobalId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/struct.GlobalId.html
 [`ConstValue::Scalar`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/value/enum.ConstValue.html#variant.Scalar
 [`ConstValue::Slice`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/value/enum.ConstValue.html#variant.Slice
 [`ConstValue::ByRef`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/value/enum.ConstValue.html#variant.ByRef
 [`EvalToConstValueResult`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/error/type.EvalToConstValueResult.html
-[`eval_const_to_op`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_const_eval/interpret/struct.InterpCx.html#method.eval_const_to_op
+[`const_to_op`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_const_eval/interpret/struct.InterpCx.html#method.const_to_op

--- a/src/miri.md
+++ b/src/miri.md
@@ -104,7 +104,7 @@ Miri, but just use the cached result.
 [`Immediate`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_const_eval/interpret/enum.Immediate.html
 [`ConstValue`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/enum.ConstValue.html
 [`Scalar`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/interpret/enum.Scalar.html
-[`op_to_const`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_const_eval/eval_queries/fn.op_to_const.html
+[`op_to_const`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_const_eval/const_eval/eval_queries/fn.op_to_const.html
 
 ## Datastructures
 


### PR DESCRIPTION
- Update function name for correct jump-to-function. I'm not sure, but I think the name of the function must have been changed during the move. The link as it was went to the `InterpCx` struct but didn't jump down to the function
- add another layer of module nesting to fix `op_to_const` 